### PR TITLE
Parallelize embryo finding

### DIFF
--- a/src/embryostage/preprocess/embryo_finder.py
+++ b/src/embryostage/preprocess/embryo_finder.py
@@ -113,7 +113,7 @@ class EmbryoFinder:
         """
         Find and crop C. elegans embryos in the time series in all FOVs in the dataset
         """
-        with multiprocessing.Pool() as pool:
+        with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
             pool.map(self._find_embryos_in_fov, self.fov_ids)
 
     def _find_embryos_in_fov(self, fov_id):


### PR DESCRIPTION
## Overview
This PR parallelizes the embryo-finding algorithm at the level of the FOVs. Because the FOVs are independent, this is an easy and obvious optimization. It is convenient in the near term to process large-ish new datasets in a reasonable time. 

For simplicity this PR uses `multiprocessing` but it seems likely that the rate-limiting ops are actually numpy or skimage calls to c-level methods and that threading would therefore achieve the same result but I did not investigate this; in my judgement it is not necessary to spend much time on this given the infrequency with which we currently need to use the embryo-finding script. 

This PR also includes a handful of incidental cleanup-related changes to update outdated comments and remove some unused instance attributes from the `EmbryoFinder` class.

## TODOs
- add error-handling or at least logging to capture uncaught errors in the parallelized `find_embryos_in_fov` method