### PR TITLE
Fix bug in embryo finding 

### DIFF
--- a/src/embryostage/preprocess/embryo_finder.py
+++ b/src/embryostage/preprocess/embryo_finder.py
@@ -156,22 +156,6 @@ class EmbryoFinder:
                 embryo_id = self.bounding_box_to_id(embryo_bounding_box)
                 embryo_path = fov_output_path / f'embryo-{embryo_id}.zarr'
 
-                output_shape = (
-                    time_series.shape[0],
-                    time_series.shape[1],
-                    time_series.shape[2],
-                    int(self.embryo_length_pix - 1),
-                    int(self.embryo_length_pix - 1),
-                )
-
-                output_store = zarr.creation.open_array(
-                    embryo_path,
-                    mode="w",
-                    shape=output_shape,
-                    chunks=output_shape,
-                    dtype=time_series.dtype,
-                )
-
                 cropped_series = time_series[
                     :,
                     :,
@@ -180,6 +164,14 @@ class EmbryoFinder:
                     embryo_bounding_box["xmin"] : embryo_bounding_box["xmax"],
                 ]
 
+                output_shape = cropped_series.shape
+                output_store = zarr.creation.open_array(
+                    embryo_path,
+                    mode="w",
+                    shape=output_shape,
+                    chunks=output_shape,
+                    dtype=time_series.dtype,
+                )
                 output_store[:] = cropped_series
 
     def _plot_results(


### PR DESCRIPTION
This PR fixes a bug in the embryo finding caused by an inconsistency of +/-1 pixel between the calculated and actual shapes of the cropped ROI around each embryo. This inconsistency only surfaced when processing the `231011` dataset (it did not occur for `230719`). 

I suspect this bug is probably related to rounding vs flooring but the details are not important because there is no need to calculate the ROI shape; the code only needs the shape _after_ the ROI is cropped, at which point we can simply use the actual shape of the ROI.